### PR TITLE
feat: create undo button in edit mode

### DIFF
--- a/app/[teamId]/[recordId]/components/sheet/buttons/undoButton.tsx
+++ b/app/[teamId]/[recordId]/components/sheet/buttons/undoButton.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@/components/ui/button';
+import { RecordDetail } from '@/types/model';
+
+type Props = {
+  record: RecordDetail;
+  setRecord: React.Dispatch<React.SetStateAction<RecordDetail>>;
+  selectedEndIndex: number;
+  setSelectedEndIndex: React.Dispatch<React.SetStateAction<number>>;
+  selectedShotIndex: number;
+  setSelectedShotIndex: React.Dispatch<React.SetStateAction<number>>;
+};
+
+export default function UndoButton({
+  record,
+  setRecord,
+  selectedEndIndex,
+  setSelectedEndIndex,
+  selectedShotIndex,
+  setSelectedShotIndex,
+}: Props) {
+
+  // Called when "Undo" button is clicked.
+  // If the first shot is selected,
+  // remove current end then select the previous end.
+  // Otherwise, remove current shot then select the previous shot.
+  const undo = () => {
+    if (selectedShotIndex === 0) {
+      setRecord(prevRecord => {
+        return {
+          ...prevRecord,
+          ends_data: prevRecord.ends_data.slice(0, selectedEndIndex),
+        };
+      })
+      setSelectedEndIndex(selectedEndIndex - 1);
+      setSelectedShotIndex(15);
+    }
+    else {
+      setRecord(prevRecord => {
+        return {
+          ...prevRecord,
+          ends_data: [
+            ...prevRecord.ends_data.slice(0, selectedEndIndex),
+            {
+              ...prevRecord.ends_data[selectedEndIndex],
+              shots: prevRecord.ends_data[selectedEndIndex].shots.slice(0, selectedShotIndex),
+            },
+          ],
+        };
+      })
+      setSelectedShotIndex(selectedShotIndex - 1);
+    }
+  }
+
+  const endsNum = record.ends_data.length;
+  const shotsNum = record.ends_data[record.ends_data.length - 1].shots.length;
+
+  return (
+    <Button
+      onClick={undo}
+      disabled={
+        selectedEndIndex < endsNum - 1 || selectedShotIndex < shotsNum - 1 ||
+        selectedEndIndex === 0 && selectedShotIndex === 0
+      }
+    >
+      Undo
+    </Button>
+  );
+}

--- a/app/[teamId]/[recordId]/components/stonePositionsSection.tsx
+++ b/app/[teamId]/[recordId]/components/stonePositionsSection.tsx
@@ -5,6 +5,7 @@ import { Sheet } from './sheet/sheet';
 import { Coordinate, Stones } from '@/types/model';
 import { SHEET_CONSTANTS } from './sheet/constants';
 import NextShotButton from './sheet/buttons/nextShotButton';
+import UndoButton from './sheet/buttons/undoButton';
 
 type Props = {
   record: RecordDetail;
@@ -107,15 +108,25 @@ export default function StonePositionsSection({
       <div className="flex space-x-4 items-center mb-4">
         <h2 className="text-xl font-medium mb-4">Stone Positions</h2>
         {isEditMode &&
-          <NextShotButton
-            record={record}
-            setRecord={setRecord}
-            selectedEndIndex={selectedEndIndex}
-            setSelectedEndIndex={setSelectedEndIndex}
-            selectedShotIndex={selectedShotIndex}
-            setSelectedShotIndex={setSelectedShotIndex}
-            onStonePositionChange={onStonePositionChange}
-          />
+          <div className="flex space-x-4">
+            <NextShotButton
+              record={record}
+              setRecord={setRecord}
+              selectedEndIndex={selectedEndIndex}
+              setSelectedEndIndex={setSelectedEndIndex}
+              selectedShotIndex={selectedShotIndex}
+              setSelectedShotIndex={setSelectedShotIndex}
+              onStonePositionChange={onStonePositionChange}
+            />
+            <UndoButton
+              record={record}
+              setRecord={setRecord}
+              selectedEndIndex={selectedEndIndex}
+              setSelectedEndIndex={setSelectedEndIndex}
+              selectedShotIndex={selectedShotIndex}
+              setSelectedShotIndex={setSelectedShotIndex}
+            />
+          </div>
         }
       </div>
       <div className="h-full mt-4">


### PR DESCRIPTION
## やったこと

- Undo ボタンの作成

## できるようになったこと

- 最新のショット選択時にボタンを有効化
- ボタン押下時の挙動
  - 1つ目のショットが選択されている場合は当該エンドを削除し、直前のエンドの最後のショットを選択
  - 2つ目以降のショットが選択されている場合は当該ショットを削除し、直前のショットを選択

## 動作確認手順

- Edit mode で実際にショットの追加と削除をおこなってみる

## 確認してほしいこと

省略