### PR TITLE
fix: redirect home when a team is deleted

### DIFF
--- a/app/[teamId]/components/buttons/deleteTeamButton.tsx
+++ b/app/[teamId]/components/buttons/deleteTeamButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -28,6 +29,8 @@ export default function DeleteTeamButton({ teamName, teamId }: DeleteTeamButtonP
   const [success, setSuccess] = useState<string | null>(null)
   const [isOpen, setIsOpen] = useState(false)
 
+  const router = useRouter()
+
   useEffect(() => {
     if (success) {
       const timer = setTimeout(() => {
@@ -54,6 +57,7 @@ export default function DeleteTeamButton({ teamName, teamId }: DeleteTeamButtonP
       revalidateByTag('getTeamsByUserId')
       setSuccess('Team deleted successfully!')
       setConfirmText('')
+      router.push('/')
     } catch (error) {
       setError('Failed to delete team. Please try again.\n' + error)
     } finally {


### PR DESCRIPTION
## やったこと

- チーム削除時にホーム画面にリダイレクト

## できるようになったこと

- 同上

## 動作確認手順

- チームの作成と削除

## 確認してほしいこと

- 正しくリダイレクトされるか